### PR TITLE
Possible fix for slow tuning/re-initialisation

### DIFF
--- a/Settings.cpp
+++ b/Settings.cpp
@@ -453,6 +453,9 @@ std::string SoapySDRPlay::IFtoString(mir_sdr_If_kHzT ifkHzT) {
         case mir_sdr_IF_2_048:
             return "2048kHz";
         break;
+        case mir_sdr_IF_Undefined:
+            return "";
+        break;
     }
     return "";
 }

--- a/SoapySDRPlay.hpp
+++ b/SoapySDRPlay.hpp
@@ -221,6 +221,8 @@ private:
     std::vector<SDRPlayGainPref> gainPrefs;
 
     void checkGainPref(double frequency);
+    bool freqBandChanged(double currentFreq, double newFreq);
+    int getFreqBand(double frequency);
 
     //device handle
 

--- a/Streaming.cpp
+++ b/Streaming.cpp
@@ -408,20 +408,20 @@ int SoapySDRPlay::readStream(
 
     if (centerFreqChanged)
     {
-        double freqDiff = std::abs(centerFreq-newCenterFreq);
+        double oldCenterFreq = centerFreq;
         centerFreq = newCenterFreq;
         centerFreqChanged = false;
 
         checkGainPref(centerFreq);
 
-        if (!gainPrefChanged && (freqDiff < rate/2.0)) {
+        if (!gainPrefChanged && !freqBandChanged(newCenterFreq, oldCenterFreq) ) {
             mir_sdr_SetRf(centerFreq, 1, 0);
         } else {
             gainPrefChanged = false;
             reInit = true;
         }
 
-        SoapySDR_log(SOAPY_SDR_DEBUG,"Changed center frequency");
+        SoapySDR_logf(SOAPY_SDR_DEBUG,"Changed center frequency : %f", newCenterFreq);
     }
 
     if (bwChanged)
@@ -476,6 +476,8 @@ int SoapySDRPlay::readStream(
         resetBuffer = false;
         grChanged = false;
         gainPrefChanged = false;
+
+        SoapySDR_log(SOAPY_SDR_DEBUG, "ReInit");
     }
 
 
@@ -616,5 +618,27 @@ void SoapySDRPlay::checkGainPref(double frequency) {
             }
         }
     }
+}
+
+// check whether centre frequency changed band
+bool SoapySDRPlay::freqBandChanged(double currentFreq, double newFreq) {
+	if ( getFreqBand(currentFreq) != getFreqBand(newFreq) )
+		return true;
+	else
+		return false;
+}
+
+
+// returns a band number for a frequency band
+int SoapySDRPlay::getFreqBand(double frequency) {
+	if (frequency >= 10000 && frequency < 12000000) return 0;
+	else if (frequency >= 12000000 && frequency < 30000000) return 1;
+	else if (frequency >= 30000000 && frequency < 60000000) return 2;
+	else if (frequency >= 60000000 && frequency < 120000000) return 3;
+	else if (frequency >= 120000000 && frequency < 250000000) return 4;
+	else if (frequency >= 250000000 && frequency < 420000000) return 5;
+	else if (frequency >= 420000000 && frequency < 1000000000) return 6;
+	else if (frequency >= 1000000000 && frequency < 2000000000) return 7;
+	else return 8;
 }
 


### PR DESCRIPTION
I had very poor performance when trying to use rx_tools which sweeps over a large band as this was causing continuous re-inits. I saw #14 and have done a fix that 'appears' to work for me but it's not fully tested. May be of use for the final fix?

There's also a little change to get rid of the pedantic compiler warning on a switch not including all the possible enums....
