### PR TITLE
Settings.cpp: fix name for undefined variable

### DIFF
--- a/Settings.cpp
+++ b/Settings.cpp
@@ -476,7 +476,7 @@ SoapySDR::RangeList SoapySDRPlay::getBandwidthRange(const int direction, const s
    //call into the older deprecated listBandwidths() call
    for (auto &bw : this->listBandwidths(direction, channel))
    {
-     ranges.push_back(SoapySDR::Range(bw, bw));
+     results.push_back(SoapySDR::Range(bw, bw));
    }
    return results;
 }


### PR DESCRIPTION
In Setting.cpp there was initialized vector results which was later called by
ranges. Change name from ranges to results so it will work properly now. Tested
locally and it compiled.