### PR TITLE
Fix unability to switch RSP2 AM port at runtime

### DIFF
--- a/Settings.cpp
+++ b/Settings.cpp
@@ -779,7 +779,14 @@ void SoapySDRPlay::writeSetting(const std::string &key, const std::string &value
    {
       if (value == "AntA/AntB") amPort = 0;
       else                      amPort = 1;
+
       mir_sdr_AmPortSelect(amPort);
+       
+      if (streamActive) {
+          mir_sdr_Reinit(&gRdB, 0.0, 0.0, mir_sdr_BW_Undefined, mir_sdr_IF_Undefined, mir_sdr_LO_Undefined, lnaState, &gRdBsystem, mir_sdr_USE_RSP_SET_GR, &sps, mir_sdr_CHANGE_AM_PORT);
+      }
+      //We apparently need to re-apply the current ant_sel
+      mir_sdr_RSPII_AntennaControl(antSel);
    }
    else if (key == "extref_ctrl")
    {

--- a/Settings.cpp
+++ b/Settings.cpp
@@ -781,12 +781,18 @@ void SoapySDRPlay::writeSetting(const std::string &key, const std::string &value
       else                      amPort = 1;
 
       mir_sdr_AmPortSelect(amPort);
-       
+
+      //If Port A/B (amPort == 0) is requested
+      //call the ant_sel to set the choice between A and B again, as advised by SDRPlay Support. 
+      if (amPort == 0) {
+          mir_sdr_RSPII_AntennaControl(antSel);
+      }
+      
+      //Required : call Reinit as Specs and SDRPlay Support advised,
+      //after the previous 2 API calls has been made (which can be made in any order)
       if (streamActive) {
           mir_sdr_Reinit(&gRdB, 0.0, 0.0, mir_sdr_BW_Undefined, mir_sdr_IF_Undefined, mir_sdr_LO_Undefined, lnaState, &gRdBsystem, mir_sdr_USE_RSP_SET_GR, &sps, mir_sdr_CHANGE_AM_PORT);
       }
-      //We apparently need to re-apply the current ant_sel
-      mir_sdr_RSPII_AntennaControl(antSel);
    }
    else if (key == "extref_ctrl")
    {


### PR DESCRIPTION
Greetings @guruofquality, @SDRplay and last but not least @cjcliffe :)
This PR  intend to fix the issue reported in CubicSDR issue  https://github.com/cjcliffe/CubicSDR/issues/508.

The reported problem was the impossibility to change RSP 2 AM port at runtime, and was oberved on OSX, Linux, and myself saw it on Windows 7 x64. (latest API v2.10)

For me, the following additional calls does the trick after calling `mir_sdr_AmPortSelect(amPort)`:

````cpp
      if (streamActive) {
          mir_sdr_Reinit(&gRdB, 0.0, 0.0, mir_sdr_BW_Undefined, mir_sdr_IF_Undefined, mir_sdr_LO_Undefined, lnaState, &gRdBsystem, mir_sdr_USE_RSP_SET_GR, &sps, mir_sdr_CHANGE_AM_PORT);
      }
      //We apparently need to re-apply the current ant_sel
      mir_sdr_RSPII_AntennaControl(antSel);
````
The clue to solve the problem was mostly inspired by @fcrohas RSP2 support branch [(commit)](https://github.com/fcrohas/SoapySDRPlay/commit/6ca187438355f88e0d0fc7047014187aee2ca5f7) later superseded by the @SDRplay own patch. 
The difference between the two was that  @fcrohas added a call
to  `mir_sdr_Reinit()` after the change of AM port, which @SDRplay branch didn't, while the API doc §3.25 indeed suggested  it was needed:
`mir_sdr_CHANGE_AM_PORT: (preceeded by mir_sdr_AmPortSelect()) requires Uninit/Init`

Still it was apparently not enough to make it work, because  I needed to recall  ` mir_sdr_RSPII_AntennaControl(antSel)` for make the thing switch.

Could you please @SDRplay review this patch, to be sure it works regardless of the platform.

I should also mention that CubicSDR v0.22 has a bit buggy "Runtime Settings" management where RSP specific settings lie, adding confusion to this issue. 
I think I've solved that aspect on the current CubicSDR master (https://github.com/cjcliffe/CubicSDR/commit/33aa0cade6c2f8e515c7faeda789952ec346f55f and later) so please test the patch with it. 