### PR TITLE
SDRPlay Enumeration fixes

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -2,6 +2,9 @@ Release 0.3.0 (pending)
 ==========================
 
 - Implement filter by serial number for enumeration
+- Enumeration can yield the already opened device:
+  Allows the device to be found again in the same process
+  and fixes multiple clients to work with SoapySDR server
 
 Release 0.2.0 (2019-01-07)
 ==========================

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,3 +1,8 @@
+Release 0.3.0 (pending)
+==========================
+
+- Implement filter by serial number for enumeration
+
 Release 0.2.0 (2019-01-07)
 ==========================
 

--- a/Registration.cpp
+++ b/Registration.cpp
@@ -37,8 +37,6 @@ bool deviceSelected = false;
 static std::vector<SoapySDR::Kwargs> findSDRPlay(const SoapySDR::Kwargs &args)
 {
    std::vector<SoapySDR::Kwargs> results;
-   std::string labelHint;
-   if (args.count("label") != 0) labelHint = args.at("label");
    unsigned int nDevs = 0;
    char lblstr[128];
 
@@ -53,60 +51,33 @@ static std::vector<SoapySDR::Kwargs> findSDRPlay(const SoapySDR::Kwargs &args)
 
    std::string baseLabel = "SDRplay Dev";
 
-	// list devices by API
+   // list devices by API
    mir_sdr_GetDevices(&rspDevs[0], &nDevs, MAX_RSP_DEVICES);
 
-   size_t posidx = labelHint.find(baseLabel);
-
-   if (posidx != std::string::npos)
-   {
-      unsigned int devIdx = labelHint.at(posidx + baseLabel.length()) - 0x30;
-
-      if ((devIdx < nDevs) && (rspDevs[devIdx].devAvail))
-      {
-         SoapySDR::Kwargs dev;
-         dev["driver"] = "sdrplay";
-         if (rspDevs[devIdx].hwVer > 253)
-         {
-             sprintf_s(lblstr, 128, "SDRplay Dev%d RSP1A %s", devIdx, rspDevs[devIdx].SerNo);
-         }
-         else if (rspDevs[devIdx].hwVer == 3)
-         {
-             sprintf_s(lblstr, 128, "SDRplay Dev%d RSPduo %s", devIdx, rspDevs[devIdx].SerNo);
-         }
-         else
-         {
-             sprintf_s(lblstr, 128, "SDRplay Dev%d RSP%d %s", devIdx, rspDevs[devIdx].hwVer, rspDevs[devIdx].SerNo);
-         }
-         dev["label"] = lblstr;
-         results.push_back(dev);
-      }
-   }
-   else
-   {
-      for (unsigned int i = 0; i < nDevs; i++)
-      {
-         if (rspDevs[i].devAvail)
-         {
-            SoapySDR::Kwargs dev;
-            dev["driver"] = "sdrplay";
-            if (rspDevs[i].hwVer > 253)
-            {
-               sprintf_s(lblstr, 128, "SDRplay Dev%d RSP1A %s", i, rspDevs[i].SerNo);
-            }
-            else if (rspDevs[i].hwVer == 3)
-            {
-               sprintf_s(lblstr, 128, "SDRplay Dev%d RSPduo %s", i, rspDevs[i].SerNo);
-            }
-            else
-            {
-               sprintf_s(lblstr, 128, "SDRplay Dev%d RSP%d %s", i, rspDevs[i].hwVer, rspDevs[i].SerNo);
-            }
-            dev["label"] = lblstr;
-            results.push_back(dev);
-         }
-      }
-   }
+  for (unsigned int i = 0; i < nDevs; i++)
+  {
+     if (rspDevs[i].devAvail)
+     {
+        SoapySDR::Kwargs dev;
+        dev["serial"] = rspDevs[i].SerNo;
+        const bool serialMatch = args.count("serial") == 0 or args.at("serial") == dev["serial"];
+        if (not serialMatch) continue;
+        if (rspDevs[i].hwVer > 253)
+        {
+           sprintf_s(lblstr, 128, "SDRplay Dev%d RSP1A %s", i, rspDevs[i].SerNo);
+        }
+        else if (rspDevs[i].hwVer == 3)
+        {
+           sprintf_s(lblstr, 128, "SDRplay Dev%d RSPduo %s", i, rspDevs[i].SerNo);
+        }
+        else
+        {
+           sprintf_s(lblstr, 128, "SDRplay Dev%d RSP%d %s", i, rspDevs[i].hwVer, rspDevs[i].SerNo);
+        }
+        dev["label"] = lblstr;
+        results.push_back(dev);
+     }
+  }
    return results;
 }
 

--- a/Registration.cpp
+++ b/Registration.cpp
@@ -29,9 +29,6 @@
 #define sprintf_s(buffer, buffer_size, stringbuffer, ...) (sprintf(buffer, stringbuffer, __VA_ARGS__))
 #endif
 
-#define MAX_RSP_DEVICES  (4)
-
-static mir_sdr_DeviceT rspDevs[MAX_RSP_DEVICES];
 bool deviceSelected = false;
 
 static std::vector<SoapySDR::Kwargs> findSDRPlay(const SoapySDR::Kwargs &args)
@@ -52,6 +49,7 @@ static std::vector<SoapySDR::Kwargs> findSDRPlay(const SoapySDR::Kwargs &args)
    std::string baseLabel = "SDRplay Dev";
 
    // list devices by API
+   mir_sdr_DeviceT rspDevs[MAX_RSP_DEVICES];
    mir_sdr_GetDevices(&rspDevs[0], &nDevs, MAX_RSP_DEVICES);
 
   for (unsigned int i = 0; i < nDevs; i++)
@@ -64,15 +62,15 @@ static std::vector<SoapySDR::Kwargs> findSDRPlay(const SoapySDR::Kwargs &args)
         if (not serialMatch) continue;
         if (rspDevs[i].hwVer > 253)
         {
-           sprintf_s(lblstr, 128, "SDRplay Dev%d RSP1A %s", i, rspDevs[i].SerNo);
+           sprintf_s(lblstr, sizeof(lblstr), "SDRplay Dev%d RSP1A %s", i, rspDevs[i].SerNo);
         }
         else if (rspDevs[i].hwVer == 3)
         {
-           sprintf_s(lblstr, 128, "SDRplay Dev%d RSPduo %s", i, rspDevs[i].SerNo);
+           sprintf_s(lblstr, sizeof(lblstr), "SDRplay Dev%d RSPduo %s", i, rspDevs[i].SerNo);
         }
         else
         {
-           sprintf_s(lblstr, 128, "SDRplay Dev%d RSP%d %s", i, rspDevs[i].hwVer, rspDevs[i].SerNo);
+           sprintf_s(lblstr, sizeof(lblstr), "SDRplay Dev%d RSP%d %s", i, rspDevs[i].hwVer, rspDevs[i].SerNo);
         }
         dev["label"] = lblstr;
         results.push_back(dev);

--- a/Settings.cpp
+++ b/Settings.cpp
@@ -24,7 +24,11 @@
 
 #include "SoapySDRPlay.hpp"
 
-extern bool deviceSelected;    // global declared in Registration.cpp
+std::set<std::string> &SoapySDRPlay_getClaimedSerials(void)
+{
+	static std::set<std::string> serials;
+	return serials;
+}
 
 SoapySDRPlay::SoapySDRPlay(const SoapySDR::Kwargs &args):
     serNo(args.at("serial"))
@@ -51,7 +55,6 @@ SoapySDRPlay::SoapySDRPlay(const SoapySDR::Kwargs &args):
     }
 
     mir_sdr_SetDeviceIdx(devIdx);
-    deviceSelected = true;
 
     sampleRate = 2000000;
     reqSampleRate = sampleRate;
@@ -88,10 +91,12 @@ SoapySDRPlay::SoapySDRPlay(const SoapySDR::Kwargs &args):
     useShort = true;
     
     streamActive = false;
+    SoapySDRPlay_getClaimedSerials().insert(serNo);
 }
 
 SoapySDRPlay::~SoapySDRPlay(void)
 {
+    SoapySDRPlay_getClaimedSerials().erase(serNo);
     std::lock_guard <std::mutex> lock(_general_state_mutex);
 
     if (streamActive)
@@ -100,7 +105,6 @@ SoapySDRPlay::~SoapySDRPlay(void)
     }
     streamActive = false;
     mir_sdr_ReleaseDeviceIdx();
-    deviceSelected = false;
 }
 
 /*******************************************************************

--- a/Settings.cpp
+++ b/Settings.cpp
@@ -26,47 +26,23 @@
 
 extern bool deviceSelected;    // global declared in Registration.cpp
 
-#define MAX_RSP_DEVICES  (4)
-
-static mir_sdr_DeviceT rspDevs[MAX_RSP_DEVICES];
-
-SoapySDRPlay::SoapySDRPlay(const SoapySDR::Kwargs &args)
+SoapySDRPlay::SoapySDRPlay(const SoapySDR::Kwargs &args):
+    serNo(args.at("serial"))
 {
-    std::string label = args.at("label");
+    // retreive hwVer and device index by API
+    unsigned int nDevs = 0;
 
-	std::string baseLabel = "SDRplay Dev";
+    mir_sdr_DeviceT rspDevs[MAX_RSP_DEVICES];
+    mir_sdr_GetDevices(&rspDevs[0], &nDevs, MAX_RSP_DEVICES);
 
-    size_t posidx = label.find(baseLabel);
-
-    if (posidx == std::string::npos)
+    unsigned devIdx = MAX_RSP_DEVICES;
+    for (unsigned int i = 0; i < nDevs; i++)
     {
-        SoapySDR_logf(SOAPY_SDR_WARNING, "Can't find Dev string in args");
-        return;
+        if (rspDevs[i].devAvail and rspDevs[i].SerNo == serNo) devIdx = i;
     }
-	//retreive device index
-    unsigned int devIdx = label.at(posidx + baseLabel.length()) - 0x30;
+    if (devIdx == MAX_RSP_DEVICES) throw std::runtime_error("no sdrplay device matches");
 
-	// retreive hwVer and serNo by API
-	unsigned int nDevs = 0;
-
-	mir_sdr_GetDevices(&rspDevs[0], &nDevs, MAX_RSP_DEVICES);
-
-	if ((devIdx < nDevs) && (rspDevs[devIdx].devAvail)) {
-
-		hwVer = rspDevs[devIdx].hwVer;
-		serNo = rspDevs[devIdx].SerNo;
-
-		size_t poscom = serNo.find(",");
-
-		if (poscom != std::string::npos)
-		{
-			serNo = serNo.substr(0, poscom);
-		}
-	}
-	else {
-		SoapySDR_logf(SOAPY_SDR_WARNING, "Can't determine hwVer/serNo");
-		return;
-	}
+    hwVer = rspDevs[devIdx].hwVer;
 
     mir_sdr_ApiVersion(&ver);
     if (ver != MIR_SDR_API_VERSION)

--- a/SoapySDRPlay.hpp
+++ b/SoapySDRPlay.hpp
@@ -45,6 +45,8 @@
 #define DEFAULT_NUM_BUFFERS       (8)
 #define DEFAULT_ELEMS_PER_SAMPLE  (2)
 
+#define MAX_RSP_DEVICES  (4)
+
 class SoapySDRPlay: public SoapySDR::Device
 {
 public:

--- a/SoapySDRPlay.hpp
+++ b/SoapySDRPlay.hpp
@@ -34,6 +34,7 @@
 #include <string>
 #include <cstring>
 #include <algorithm>
+#include <set>
 
 #ifdef _WIN32
 #include <mir_sdr.h>
@@ -46,6 +47,8 @@
 #define DEFAULT_ELEMS_PER_SAMPLE  (2)
 
 #define MAX_RSP_DEVICES  (4)
+
+std::set<std::string> &SoapySDRPlay_getClaimedSerials(void);
 
 class SoapySDRPlay: public SoapySDR::Device
 {


### PR DESCRIPTION
- Implement filter by serial number for enumeration
- Enumeration can yield the already opened device:
  Allows the device to be found again in the same process
  and fixes multiple clients to work with SoapySDR server
- Resolves https://github.com/pothosware/SoapySDRPlay/issues/46