### PR TITLE
Bring SDRPlay gain handling in line with SoapySDR abstractions.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,11 +38,12 @@ if(CMAKE_COMPILER_IS_GNUCXX)
 
 endif(CMAKE_COMPILER_IS_GNUCXX)
 
-# Configurable feature set 
-SET (RF_GAIN_IN_MENU ON CACHE BOOL "Add Rf gain as a setting, additionally to the IFGR gain control")
+# The SDRPlay LNA state, aka "RF gain", is more properly a setting than a gain.
+# However, some users may prefer to also expose it as a SoapySDR gain.
+SET (LNA_STATE_AS_GAIN OFF CACHE BOOL "Duplicate the lna_state setting as a SoapySDR gain.")
 
-IF(RF_GAIN_IN_MENU) 
-    ADD_DEFINITIONS( -DRF_GAIN_IN_MENU=1 )
+IF(LNA_STATE_AS_GAIN)
+    ADD_DEFINITIONS( -DLNA_STATE_AS_GAIN=1 )
 ENDIF()
 
 SOAPY_SDR_MODULE_UTIL(

--- a/Settings.cpp
+++ b/Settings.cpp
@@ -435,8 +435,8 @@ void SoapySDRPlay::setGain(const int direction, const size_t channel, const std:
 
 void SoapySDRPlay::setGain(const int direction, const size_t channel, const double value)
 {
-   // Only IFGR should be used for adjusting the overall system gain.
-   this->setGain(direction, channel, "IFGR", value);
+   // Only IF should be used for adjusting the overall system gain.
+   this->setGain(direction, channel, "IF", value);
 }
 
 double SoapySDRPlay::getGain(const int direction, const size_t channel, const std::string &name) const
@@ -475,8 +475,8 @@ SoapySDR::Range SoapySDRPlay::getGainRange(const int direction, const size_t cha
 
 SoapySDR::Range SoapySDRPlay::getGainRange(const int direction, const size_t channel) const
 {
-   // Only IFGR should be used for adjusting the overall system gain.
-   return this->getGainRange(direction, channel, "IFGR");
+   // Only IF should be used for adjusting the overall system gain.
+   return this->getGainRange(direction, channel, "IF");
 }
 
 /*******************************************************************

--- a/Settings.cpp
+++ b/Settings.cpp
@@ -421,6 +421,12 @@ void SoapySDRPlay::setGain(const int direction, const size_t channel, const std:
    }
 }
 
+void SoapySDRPlay::setGain(const int direction, const size_t channel, const double value)
+{
+   // Only IFGR should be used for adjusting the overall system gain.
+   this->setGain(direction, channel, "IFGR", value);
+}
+
 double SoapySDRPlay::getGain(const int direction, const size_t channel, const std::string &name) const
 {
     std::lock_guard <std::mutex> lock(_general_state_mutex);
@@ -460,6 +466,12 @@ SoapySDR::Range SoapySDRPlay::getGainRange(const int direction, const size_t cha
       return SoapySDR::Range(0, 9);
    }
     return SoapySDR::Range(20, 59);
+}
+
+SoapySDR::Range SoapySDRPlay::getGainRange(const int direction, const size_t channel) const
+{
+   // Only IFGR should be used for adjusting the overall system gain.
+   return this->getGainRange(direction, channel, "IFGR");
 }
 
 /*******************************************************************

--- a/SoapySDRPlay.hpp
+++ b/SoapySDRPlay.hpp
@@ -153,9 +153,13 @@ public:
 
     void setGain(const int direction, const size_t channel, const std::string &name, const double value);
 
+    void setGain(const int direction, const size_t channel, const double value);
+
     double getGain(const int direction, const size_t channel, const std::string &name) const;
 
     SoapySDR::Range getGainRange(const int direction, const size_t channel, const std::string &name) const;
+
+    SoapySDR::Range getGainRange(const int direction, const size_t channel) const;
 
     /*******************************************************************
      * Frequency API

--- a/SoapySDRPlay.hpp
+++ b/SoapySDRPlay.hpp
@@ -258,6 +258,7 @@ private:
     int gRdBsystem;
     int sps;
     int lnaState;
+    int maxLnaState;
     int hwVer;
 
     //cached settings


### PR DESCRIPTION
This PR solves #44 and #60. Summary of changes:

1. Rename IFGR to IF, and negate it. (For example, an "Intermediate Frequency Gain Reduction" of +30 dB is now interpreted as an IF gain of -30 dB.)
2. Remove RFGR from the list of gains. Instead, RFGR is adjusted using the equivalent "RF Gain Select" setting. (RF can be re-added to the list of gains via an optional build flag.)
3. Override `setGain` and `getGainRange` so that setting an overall system gain will adjust the IF gain only. RF gain should not be adjusted implicitly.
4. Rename the `rfgain_sel` setting to `lna_state` for semantic consistency.

The impact on CubicSDR clients will be the following:

1.  CubicSDR in manual gain mode will have an IF gain slider labeled -59 at the bottom and -20 at the top, with the greatest amplification obtained at the top of the slider. This replaces the old IFGR slider, which was backwards from usual (it was labeled 20 at the bottom and 59 at the top, with the greatest amplification at the *lowest* setting).
2. The RFGR slider is no longer present in manual gain mode. The RF gain is settable in any mode by means of the "RF Gain Select" menu item. A build option (off by default) adds an RF gain slider in manual gain mode. RF gain values on this slider are negated from the previous RFGR slider (-9 through 0 instead of 0 through 9) for directional consistency with the other gain sliders.

This PR will require that any other applications which explicitly set IFGR, RFGR, or rfgain_sel by name must update their configuration files. It will introduce compatibility with any application that calls `Device::setGain` without a name.

I have built and tested this PR with an RSP1A, using CubicSDR (to verify manual and automatic gain control work properly) and trunk-recorder (to validate that `Device::setGain` with no name now has reasonable behavior).

References:
1. Block diagram of RF and IF gains: [SDRPlay application note](https://www.sdrplay.com/wp-content/uploads/2018/06/Gain_and_AGC_in_SDRuno.pdf)
2. Actual dB losses caused by RF Gain setting: [SDRPlay API documentation](https://www.sdrplay.com/docs/SDRplay_SDR_API_Specification.pdf), section 5.3