### PR TITLE
Allow extra arguments in the device string to change settings

### DIFF
--- a/Settings.cpp
+++ b/Settings.cpp
@@ -88,6 +88,17 @@ SoapySDRPlay::SoapySDRPlay(const SoapySDR::Kwargs &args)
     notchEn = 0;
     dabNotchEn = 0;
 
+    // process additional device string arguments
+    for (std::pair<std::string, std::string> arg : args) {
+        // ignore 'driver', 'label', 'mode', 'serial', and 'soapy'
+        if (arg.first == "driver" || arg.first == "label" ||
+            arg.first == "mode" || arg.first == "serial" ||
+            arg.first == "soapy") {
+            continue;
+        }
+        writeSetting(arg.first, arg.second);
+    }
+
     bufferedElems = 0;
     _currentBuff = 0;
     resetBuffer = false;


### PR DESCRIPTION
This pull request adds calls to the method `writeSetting()` in the constructor to allow extra arguments (like `biasT_ctrl`) in the device string, so that they can be used to set specific device settings during initialization.

See discussion here: https://github.com/pothosware/SoapySDRPlay2/issues/71#issuecomment-974798732